### PR TITLE
Refactoring for extensibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+__pycache__
+Attic
+.vscode

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Parameters for Type: Custom::CreateCertificates :
 - IdempotencyToken: (REQUIRED type:string pattern: \w+) The idempotency token for the create call of the acm certificate
   doc: https://docs.aws.amazon.com/acm/latest/APIReference/API_RequestCertificate.html#ACM-RequestCertificate-request-IdempotencyToken
 - CertificateTags: (OPTIONAL type:list) The tags for the acm certificate
+- KeepDNSRecord (OPTIONAL type:String) If value is set to "yes", the Validation records will not be deleted.
 
 Outputs for Type: Custom::CreateCertificates :
 - certificate_arn: The arn of the acm certificate created by the custom resource. (!GetAtt NameCustomResource.certificate_arn)

--- a/README.md
+++ b/README.md
@@ -37,15 +37,7 @@ to the S3 bucket you want to use with your custom resource in a cloudformation t
 
 ## Implementation notes
 
-See cfn.yaml as an example.
-
-IMPORTANT:  
-For the delete and cleanup functionality it is required to set the following output in your cloudformation.
-
-`Outputs:`  
-&nbsp;&nbsp;  `NameCustomResource:`  
-&nbsp;&nbsp;&nbsp;&nbsp;    `Description: The arn of the certificate created by NameCustomResource `  
-&nbsp;&nbsp;&nbsp;&nbsp;    `Value: !GetAtt NameCustomResource.certificate_arn`  
+See cfn.yaml as an example. 
 
 Parameters for Type: Custom::CreateCertificates :
 - DomainName: (REQUIRED type:String) The domain name for the acm certificate.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cloudar-acm-plus
 
 A custom resource written in Python to create acm certificates in cloudformation
-with automatic DNS validation for domains managed by AWS hostedzone and the option to create the certificate in a different region then the cloudformation stack region.
+with automatic DNS validation for domains managed by AWS Route53 or another DNS solution and the option to create the certificate in a different region then the cloudformation stack region.
 
 ## Features
 
@@ -12,6 +12,7 @@ with automatic DNS validation for domains managed by AWS hostedzone and the opti
         - Validation domain
         - Region
         - Tags
+        - DnsService (Currently Route53 or MenAndMice)
 - Automatic DNS validation of the acm certificate
 - Specify AWS region to create the certificate in, independent of the Cloudformation stack region
 - Cleanup DNS validation records and deleting the acm certificate on delete of the Cloudformation stack     
@@ -49,8 +50,11 @@ For the delete and cleanup functionality it is required to set the following out
 Parameters for Type: Custom::CreateCertificates :
 - DomainName: (REQUIRED type:String) The domain name for the acm certificate.
 - AdditionalDomains: (OPTIONAL type:List) Additional domains for the acm certificate
-- ValidationDomain: (REQUIRED type:string) The domain name for the validation domain of the acm certificate
-- HostedZoneId: (REQUIRED type:string) The hosted zone id for the validation domain of the acm certificate
+- ValidationDomain: (REQUIRED type:String) The domain name for the validation domain of the acm certificate
+- HostedZoneId: (OPTIONAL (REQUIRED FOR Route53) type:string) The hosted zone id for the validation domain of the acm certificate
+- DnsApiCredentialLocation: (OPTIONAL (REQUIRED FOR MenAndMice) type:String) SSM Parameter Store path where credentials and api url is stored. (SecureString)
+  The script will be looking for username, password and apiurl ssm parameters in the path. in case of MenAndMice dns service.
+- HostedZoneName; (OPTIONAL (REQUIRED FOR MenAndMice) type:String) Zone name to add the dns validation record to 
 - CertificateRegion: (REQUIRED type:string) The region to deploy the acm certificate in
 - IdempotencyToken: (REQUIRED type:string pattern: \w+) The idempotency token for the create call of the acm certificate
   doc: https://docs.aws.amazon.com/acm/latest/APIReference/API_RequestCertificate.html#ACM-RequestCertificate-request-IdempotencyToken

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -2,10 +2,7 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: >
     This template deploys a custom resource and acm certificate.
 Parameters:
-  HostedZoneId:
-    Description: The hostedzone id for the env domain
-    Type: String
-    Default: ""
+
   DomainName:
     Description: the domainname for the env
     Type: String
@@ -20,6 +17,20 @@ Parameters:
     AllowedValues:
       - Route53
       - MenAndMice
+      
+  # Only needed if DnsService is Route53    
+  HostedZoneId:
+    Description: The hostedzone id for the env domain
+    Type: String
+    Default: ""    
+  
+  # Only needed if DnsService is not Route53
+  HostedZoneName:
+    Type: String
+    Default: ""
+  DnsApiCredentialLocation:
+    Type: String
+    Default: "/menandmice/"
 
 Resources:
 
@@ -39,6 +50,14 @@ Resources:
       Code:
         S3Bucket: !Sub ${ArtifactBucket}
         S3Key: "cloudar-acm-plus-custom-resource.zip"
+      # VPC Config is only needed if dnS Service is not Route53
+      VpcConfig:
+        SecurityGroupIds:
+          - <YOUR Security Group>
+        SubnetIds:
+          - <YOUR SUBNET A>
+          - <YOUR SUBNET B>
+          - <YOUR SUBNET C>
 
   CreateCertificatesFunctionExecutionRole:
     Type: AWS::IAM::Role
@@ -54,7 +73,20 @@ Resources:
         - arn:aws:iam::aws:policy/AWSCertificateManagerFullAccess
         - arn:aws:iam::aws:policy/AmazonRoute53FullAccess
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         - arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+      Policies:
+        - PolicyName: ssmAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action: 
+                  - ssm:GetParametersByPath
+                  - ssm:GetParameter
+                Effect: Allow
+                Resource:
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/menandmice/
+                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/menandmice/*
 
   CreateCertificateCustomResource:
     Type: Custom::CreateCertificates

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -12,6 +12,8 @@ Parameters:
   ArtifactBucket:
     Description: the artifact bucket
     Type: String
+    
+
   DnsService:
     Description: "Route53, MenAndMice"
     Type: String
@@ -60,8 +62,6 @@ Resources:
       ServiceToken: !GetAtt CreateCertificatesFunction.Arn
       DnsService: !Ref DnsService
       DomainName: !Ref DomainName
-      AdditionalDomains:
-        - !Sub www.${DomainName}
       ValidationDomain: !Ref DomainName
       HostedZoneId: !Ref HostedZoneId
       CertificateRegion: !Ref AWS::Region

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -2,15 +2,22 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: >
     This template deploys a custom resource and acm certificate.
 Parameters:
-    HostedZoneId:
-        Description: The hostedzone id for the env domain
-        Type: String
-    DomainName:
-        Description: the domainname for the env
-        Type: String
-    ArtifactBucket:
-        Description: the artifact bucket
-        Type: String
+  HostedZoneId:
+    Description: The hostedzone id for the env domain
+    Type: String
+    Default: ""
+  DomainName:
+    Description: the domainname for the env
+    Type: String
+  ArtifactBucket:
+    Description: the artifact bucket
+    Type: String
+  DnsService:
+    Description: "Route53, MenAndMice"
+    Type: String
+    AllowedValues:
+      - Route53
+      - MenAndMice
 
 Resources:
 
@@ -51,16 +58,17 @@ Resources:
     Type: Custom::CreateCertificates
     Properties:
       ServiceToken: !GetAtt CreateCertificatesFunction.Arn
-      DomainName: !Sub ${DomainName}
+      DnsService: !Ref DnsService
+      DomainName: !Ref DomainName
       AdditionalDomains:
         - !Sub www.${DomainName}
-      ValidationDomain: !Sub ${DomainName}
-      HostedZoneId: !Sub ${HostedZoneId}
-      CertificateRegion: !Sub "${AWS::Region}"
+      ValidationDomain: !Ref DomainName
+      HostedZoneId: !Ref HostedZoneId
+      CertificateRegion: !Ref AWS::Region
       IdempotencyToken: CreateCertificateCustomResource
       CertificateTags:
         - Key: Name
-          Value: !Sub ${DomainName}
+          Value: !Ref DomainName
 
 Outputs:
   CreateCertificateCustomResource:

--- a/cloudar-acm-plus-custom-resource/install_dependencies
+++ b/cloudar-acm-plus-custom-resource/install_dependencies
@@ -1,1 +1,2 @@
-pip3 install -r requirements.txt -t src
+scriptdir=$(dirname $0)
+pip3 install -r ${scriptdir}/requirements.txt -t src

--- a/cloudar-acm-plus-custom-resource/pack_custom_resource
+++ b/cloudar-acm-plus-custom-resource/pack_custom_resource
@@ -1,3 +1,5 @@
+scriptdir=$(dirname $0)
+cp -rp ${scriptdir}/src/* src/ 
 mkdir -p packed
 pushd src
 zip -r $OLDPWD/packed/cloudar-acm-plus-custom-resource.zip *

--- a/cloudar-acm-plus-custom-resource/requirements.txt
+++ b/cloudar-acm-plus-custom-resource/requirements.txt
@@ -1,2 +1,3 @@
 cfnresponse
 boto3
+requests

--- a/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
@@ -2,28 +2,32 @@ import boto3
 import logging
 import time
 import requests
-from helper import get_resource_property,strip_domain
+from helper import get_resource_property, strip_domain
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
 
 class MenAndMice:
 
     def __init__(self):
         self.client = None
-        self.credential_store = 'ssm' #For now only ssm is used to retrieve credentials
+        self.credential_store = 'ssm'  # For now only ssm is used to retrieve credentials
         self.credentials = None
-        self.server = None 
+        self.headers = {'content-type': 'application/json'}
+        self.apiurl = None
+        self.server = None
         self.records = []
         self.mmsession = requests.Session()
+        self.zonetype = 'external'
         logger.info(self.__class__.__name__ + " initialized")
-        
-        
+
     def get_credentials(self):
-        handle_credentials = getattr(self, 'get_credentials_from_' + self.credential_store, None)
+        handle_credentials = getattr(
+            self, 'get_credentials_from_' + self.credential_store, None)
         if callable(handle_credentials):
-            self.handle_credentials()
-        
+            handle_credentials()
+
     def get_credentials_from_ssm(self):
         password = None
         username = None
@@ -31,42 +35,44 @@ class MenAndMice:
         client = boto3.client('ssm')
         response = client.get_parameters_by_path(
             Path=self.credential_store_location,
-            Recursive = False,
-            WithDecryption=True
-        )
+            Recursive=False,
+            WithDecryption=True)
+        #print(response)
         for parameter in response['Parameters']:
-            if parameter['Name'] == 'username':
+            logger.info("Found SSM Parameter %s", parameter['Name'])
+            #print(self.credential_store_location + 'apiurl')
+            if parameter['Name'] == self.credential_store_location + 'username':
                 username = parameter['Value']
-            elif parameter['Name'] == 'password':
+            elif parameter['Name'] == self.credential_store_location + 'password':
                 password = parameter['Value']
-            elif parameter['Name'] == 'apiurl':
+            elif parameter['Name'] == self.credential_store_location + 'apiurl':
                 apiurl = parameter['Value']
-            
-        self.credentials=(username, password)
-        self.apiurl = apiurl
-        
 
-    def handle_event(self,event):
+        self.credentials = (username, password)
+        self.apiurl = apiurl
+        logger.info("Returning values: username=%s, apiurl=%s",
+                    username, apiurl)
+
+    def handle_event(self, event):
         self.credential_store_location = get_resource_property(
             event, 'DnsApiCredentialLocation')
         if not self.credential_store_location:
-            raise AttributeError(self.__class__.__name__ +
-                                 " Requires DnsApiCredentialLocation Parameter")
+            raise AttributeError(
+                self.__class__.__name__ +
+                " Requires DnsApiCredentialLocation Parameter")
         self.hosted_zone_name = get_resource_property(event, 'HostedZoneName')
         if not self.hosted_zone_name:
             raise AttributeError(self.__class__.__name__ +
                                  " Requires HostedZoneName Parameter")
-                                 
+
         self.get_credentials()
-        
+
     def select_zone(self):
         zones = []
-        zoneparams={'filter': 'name=' + self.hosted_zone_name + "."}
+        zoneparams = {'filter': 'name=' + self.hosted_zone_name + "."}
         response = self.mmsession.get(
             self.apiurl + '/DNSZones/', params=zoneparams, headers=self.headers, auth=self.credentials)
 
-
-        
         if response.ok:
             for zone in response.json()['result']['dnsZones']:
                 if 'localhost.' in zone['name'] or 'in-addr.arpa' in zone['name']:
@@ -75,50 +81,69 @@ class MenAndMice:
                 else:
                     zones.append({'name': zone['name'], 'ref': zone['ref'],
                                  'type': zone['type'], 'displayName': zone['displayName']})
-        
+
         return zones
 
-    def dns_record_exists(self,record_name,record_value):
+    def dns_record_exists(self, record_name, record_value):
         logger.info(
             "Checking if record already exists: Record Name = %s, Record Value = %s.",
             record_name, record_value)
 
-        host_name = strip_domain(record_name, self.hosted_zone_name)
+        host_name = strip_domain(record_name, self.hosted_zone_name + ".")
 
-        zone_params = {'filter': 'name=' + self.hosted_zone_name + '.&type=Master'}
-        response = self.mmsession.get(
-            self.apiurl + '/DNSZones/', params=zone_params, headers=self.headers, auth=self.credentials)
-        
-        record_params = {'filter': 'type=CNAME&name='+ host_name }
+        zone_params = {
+            'filter': 'name=' + self.hosted_zone_name + '.&type=Master'
+        }
+        logger.info("zone_params: %s, hostname: %s",
+                    zone_params['filter'], host_name)
+        logger.info("apiurl: %s", self.apiurl)
+        response = self.mmsession.get(self.apiurl + '/DNSZones/',
+                                      params=zone_params,
+                                      headers=self.headers,
+                                      auth=self.credentials)
+
+        record_params = {'filter': 'type=CNAME&name=' + host_name}
+        logger.info("record_params: %s", record_params['filter'])
         if response.ok:
             for zone in response.json()['result']['dnsZones']:
-                resp = self.mmsession.get(self.apiurl + "/" + zone['ref'] + '/DNSRecords', params=record_params, auth=self.credentials, headers=self.headers)
-            if resp.ok:
-                for rec in resp.json()['result']['dnsRecords']:
-                    self.records.append(rec)
+                logger.info("Checking zone %s (%s)", zone['name'], zone['ref'])
+                resp = self.mmsession.get(self.apiurl + "/" + zone['ref'] +
+                                          '/DNSRecords',
+                                          params=record_params,
+                                          auth=self.credentials,
+                                          headers=self.headers)
+                if resp.ok:
+                    for rec in resp.json()['result']['dnsRecords']:
+                        self.records.append(rec)
         if self.records and len(self.records) > 0:
             logger.info("Record exists")
             return True
         logger.info("Record does not exist")
         return False
 
-    def modify_dns_record(self, action, record_name, record_value): 
+    def modify_dns_record(self, action, record_name, record_value):
         record_exists = self.dns_record_exists(record_name, record_value)
         if not record_exists or action == "DELETE":
             if action == "DELETE":
                 for record in self.records:
-                    response = self.mmsession.delete(self.apiurl + "/" + record['ref'], headers=self.headers, auth=self.credentials)
+                    response = self.mmsession.delete(self.apiurl + "/" +
+                                                     record['ref'],
+                                                     headers=self.headers,
+                                                     auth=self.credentials)
                     if response.ok:
-                        logger.info(record['name'] + ' (' + record['ref'] + ') Deleted')
+                        logger.info(record['name'] + ' (' + record['ref'] +
+                                    ') Deleted')
                     else:
-                        logger.warn("Could not delete " + record['name'] + ' (' + record['ref'] + ')')
+                        logger.warn("Could not delete " + record['name'] +
+                                    ' (' + record['ref'] + ')')
             else:
                 # Create new record
                 zones = self.select_zone()
 
                 myrecord = record_name
                 mydomain = self.hosted_zone_name
-                myhostname = strip_domain(record_name, self.hosted_zone_name)
+                myhostname = strip_domain(
+                    record_name, self.hosted_zone_name + ".")
 
                 record = {
                     "dnsRecord": {
@@ -127,14 +152,19 @@ class MenAndMice:
                         "data": record_value
                     }
                 }
+                #print(record)
                 for zone in zones:
-                    response = self.mmsession.post(self.apiurl + '/' + zone['ref'] + '/DNSRecords',
-                                            json=record, headers=self.headers, auth=self.credentials)
+                    #print(zone)
+                    response = self.mmsession.post(self.apiurl + '/' +
+                                                   zone['ref'] + '/DNSRecords',
+                                                   json=record,
+                                                   headers=self.headers,
+                                                   auth=self.credentials)
                     if response.ok:
                         logger.info("DNS Record created in Zone " +
-                                    self.hosted_zone_name + "(" + zone['ref'] + ")")
+                                    self.hosted_zone_name + "(" + zone['ref'] +
+                                    ")")
                     else:
                         logger.error(response.json())
-                
         else:
             logger.info("Record exists, skipping create.")

--- a/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
@@ -2,7 +2,7 @@ import boto3
 import logging
 import time
 import requests
-from helper import get_resource_property
+from helper import get_resource_property,strip_domain
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -13,8 +13,11 @@ class MenAndMice:
         self.client = None
         self.credential_store = 'ssm' #For now only ssm is used to retrieve credentials
         self.credentials = None
-        self.headers = {'content-type': 'application/json'}
+        self.server = None 
+        self.records = []
+        self.mmsession = requests.Session()
         logger.info(self.__class__.__name__ + " initialized")
+        
         
     def get_credentials(self):
         handle_credentials = getattr(self, 'get_credentials_from_' + self.credential_store, None)
@@ -24,6 +27,7 @@ class MenAndMice:
     def get_credentials_from_ssm(self):
         password = None
         username = None
+        apiurl = None
         client = boto3.client('ssm')
         response = client.get_parameters_by_path(
             Path=self.credential_store_location,
@@ -35,9 +39,11 @@ class MenAndMice:
                 username = parameter['Value']
             elif parameter['Name'] == 'password':
                 password = parameter['Value']
+            elif parameter['Name'] == 'apiurl':
+                apiurl = parameter['Value']
             
         self.credentials=(username, password)
-        
+        self.apiurl = apiurl
         
 
     def handle_event(self,event):
@@ -46,11 +52,6 @@ class MenAndMice:
         if not self.credential_store_location:
             raise AttributeError(self.__class__.__name__ +
                                  " Requires DnsApiCredentialLocation Parameter")
-        self.apiurl = get_resource_property(
-            event, 'DnsApiUrl')
-        if not self.apiurl:
-            raise AttributeError(self.__class__.__name__ +
-                                 " Requires DnsApiUrl Parameter")
         self.hosted_zone_name = get_resource_property(event, 'HostedZoneName')
         if not self.hosted_zone_name:
             raise AttributeError(self.__class__.__name__ +
@@ -64,20 +65,37 @@ class MenAndMice:
             "Checking if record already exists: Record Name = %s, Record Value = %s.",
             record_name, record_value)
 
-        start_record_name = record_name.split('.')[0]
-        #TODO: Implement M&M API
-        mmsession = requests.Session()
-        Params = {'filter': 'type=CNAME,name='+ record_name }
-        response = mmsession.get(self.apiurl + '/DNSZones/' + self.hosted_zone_name +
-                                 '/DNSRecords', headers=self.headers, auth=self.credentials)
+        host_name = strip_domain(record_name, self.hosted_zone_name)
 
+        zone_params = {'filter': 'name=' + self.hosted_zone_name + '.&type=Master'}
+        response = self.mmsession.get(
+            self.apiurl + '/DNSZones/', params=zone_params, headers=self.headers, auth=self.credentials)
+        
+        record_params = {'filter': 'type=CNAME&name='+ host_name }
+        if response.ok:
+            for zone in response.json()['result']['dnsZones']:
+                resp = self.mmsession.get(self.apiurl + "/" + zone['ref'] + '/DNSRecords', params=record_params, auth=self.credentials, headers=self.headers)
+            if resp.ok:
+                for rec in resp.json()['result']['dnsRecords']:
+                    self.records.append(rec)
+        if self.records and len(self.records) > 0:
+            logger.info("Record exists")
+            return True
         logger.info("Record does not exist")
         return False
 
-    def modify_dns_record(self, action, record_name, record_value):
+    def modify_dns_record(self, action, record_name, record_value): 
         record_exists = self.dns_record_exists(record_name, record_value)
         if not record_exists or action == "DELETE":
-            #TODO: Implement M&M API
-            pass
+            if action == "DELETE":
+                for record in self.records:
+                    response = self.mmsession.delete(self.apiurl + "/" + record['ref'], headers=self.headers, auth=self.credentials)
+                    if response.ok:
+                        logger.info(record['name'] + ' (' + record['ref'] + ') Deleted')
+                    else:
+                        logger.warn("Could not delete " + record['name'] + ' (' + record['ref'] + ')')
+            else:
+                # Create new record
+                pass
         else:
             logger.info("Record exists, skipping create.")

--- a/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
@@ -1,0 +1,35 @@
+import boto3
+import logging
+import time
+from helper import get_resource_property
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+class MenAndMice:
+
+    def __init__(self):
+        self.client = None
+
+    #def handle_event(self,event):
+    #  #TODO: Implement M&M API
+
+
+    def dns_record_exists(self,record_name,record_value):
+        logger.info(
+            "Checking if record already exists: Hosted Zone = %s, Record Name = %s, Record Value = %s.",
+            self.hosted_zone_id, record_name, record_value)
+
+        start_record_name = record_name.split('.')[0]
+        #TODO: Implement M&M API
+
+        logger.info("Record does not exist")
+        return False
+
+    def modify_dns_record(self, action, record_name, record_value):
+        record_exists = self.dns_record_exists(record_name, record_value)
+        if not record_exists or action == "DELETE":
+            #TODO: Implement M&M API
+            pass
+        else:
+            logger.info("Record exists, skipping create.")

--- a/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
@@ -61,7 +61,7 @@ class MenAndMice:
         
     def select_zone(self):
         zones = []
-        zoneparams={'filter': 'name=' + self.hosted_zone_name}
+        zoneparams={'filter': 'name=' + self.hosted_zone_name + "."}
         response = self.mmsession.get(
             self.apiurl + '/DNSZones/', params=zoneparams, headers=self.headers, auth=self.credentials)
 

--- a/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
@@ -13,6 +13,7 @@ class MenAndMice:
         self.client = None
         self.credential_store = 'ssm' #For now only ssm is used to retrieve credentials
         self.credentials = None
+        self.headers = {'content-type': 'application/json'}
         logger.info(self.__class__.__name__ + " initialized")
         
     def get_credentials(self):
@@ -65,6 +66,10 @@ class MenAndMice:
 
         start_record_name = record_name.split('.')[0]
         #TODO: Implement M&M API
+        mmsession = requests.Session()
+        Params = {'filter': 'type=CNAME,name='+ record_name }
+        response = mmsession.get(self.apiurl + '/DNSZones/' + self.hosted_zone_name +
+                                 '/DNSRecords;', headers=self.headers, auth=self.credentials)
 
         logger.info("Record does not exist")
         return False

--- a/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
@@ -131,9 +131,10 @@ class MenAndMice:
                     response = self.mmsession.post(self.apiurl + '/' + zone['ref'] + '/DNSRecords',
                                             json=record, headers=self.headers, auth=self.credentials)
                     if response.ok:
-                        print(response.json())
+                        logger.info("DNS Record created in Zone " +
+                                    self.hosted_zone_name + "(" + zone['ref'] + ")")
                     else:
-                        print(response.json())
+                        logger.error(response.json())
                 
         else:
             logger.info("Record exists, skipping create.")

--- a/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/menandmice.py
@@ -69,7 +69,7 @@ class MenAndMice:
         mmsession = requests.Session()
         Params = {'filter': 'type=CNAME,name='+ record_name }
         response = mmsession.get(self.apiurl + '/DNSZones/' + self.hosted_zone_name +
-                                 '/DNSRecords;', headers=self.headers, auth=self.credentials)
+                                 '/DNSRecords', headers=self.headers, auth=self.credentials)
 
         logger.info("Record does not exist")
         return False

--- a/cloudar-acm-plus-custom-resource/src/dns/route53.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/route53.py
@@ -1,0 +1,65 @@
+import boto3
+import logging
+import time
+from helper import get_resource_property
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+class Route53:
+
+    def __init__(self):
+        self.certificate_region = None
+        self.client = None
+
+    def handle_event(self,event):
+        self.certificate_region = get_resource_property(event, 'CertificateRegion')
+        self.client = boto3.client('route53',region_name=self.certificate_region)
+        self.hosted_zone_id = get_resource_property(event, 'HostedZoneId')
+        if not self.hosted_zone_id:
+            raise AttributeError(self.__class__.__name__  + " Requires HostedZoneId Parameter")
+
+    
+    def dns_record_exists(self,record_name,record_value):
+        logger.info(
+            "Checking if record already exists: Hosted Zone = %s, Record Name = %s, Record Value = %s.",
+            self.hosted_zone_id, record_name, record_value)
+
+        start_record_name = record_name.split('.')[0]
+        iterator = self.client.get_paginator('list_resource_record_sets').paginate(HostedZoneId=self.hosted_zone_id)
+        for page in iterator:
+            for record in page.get('ResourceRecordSets'):
+                if record_name == record['Name']:
+                    logger.info("Record exists")
+                    return True
+
+        logger.info("Record does not exist")
+        return False
+        
+    def modify_dns_record(self, action, record_name, record_value):
+        record_exists = self.dns_record_exists(record_name, record_value)
+        if not record_exists or action == "DELETE":
+            response = self.client.change_resource_record_sets(
+                HostedZoneId=self.hosted_zone_id,
+                ChangeBatch={
+                    'Changes': [
+                        {
+                            'Action': action,
+                            'ResourceRecordSet': {
+                                'Name': record_name,
+                                'SetIdentifier': record_name,
+                                'TTL': 60,
+                                'Type': 'CNAME',
+                                'Region': self.certificate_region,
+                                'ResourceRecords': [
+                                    {
+                                        'Value': record_value
+                                    },
+                                ]
+                            }
+                        }
+                    ]
+                }
+            )
+        else:
+            logger.info("Record exists, skipping create.")

--- a/cloudar-acm-plus-custom-resource/src/dns/route53.py
+++ b/cloudar-acm-plus-custom-resource/src/dns/route53.py
@@ -11,6 +11,7 @@ class Route53:
     def __init__(self):
         self.certificate_region = None
         self.client = None
+        logger.info(self.__class__.__name__ + " initialized")
 
     def handle_event(self,event):
         self.certificate_region = get_resource_property(event, 'CertificateRegion')
@@ -48,9 +49,9 @@ class Route53:
                             'ResourceRecordSet': {
                                 'Name': record_name,
                                 'SetIdentifier': record_name,
+                                'Region': self.certificate_region,
                                 'TTL': 60,
                                 'Type': 'CNAME',
-                                'Region': self.certificate_region,
                                 'ResourceRecords': [
                                     {
                                         'Value': record_value

--- a/cloudar-acm-plus-custom-resource/src/helper.py
+++ b/cloudar-acm-plus-custom-resource/src/helper.py
@@ -9,4 +9,5 @@ def get_resource_property(event, resource_property):
 def strip_domain(fqdn, domain):
     if fqdn.endswith("." + domain):
         return fqdn[:-(len("." + domain))]
-    return None
+    else:
+        return fqdn

--- a/cloudar-acm-plus-custom-resource/src/helper.py
+++ b/cloudar-acm-plus-custom-resource/src/helper.py
@@ -1,0 +1,6 @@
+def get_resource_property(event, resource_property):
+    resource_properties = event['ResourceProperties']
+    if resource_property in resource_properties:
+        return resource_properties[resource_property]
+    else:
+        return None

--- a/cloudar-acm-plus-custom-resource/src/helper.py
+++ b/cloudar-acm-plus-custom-resource/src/helper.py
@@ -4,3 +4,9 @@ def get_resource_property(event, resource_property):
         return resource_properties[resource_property]
     else:
         return None
+        
+
+def strip_domain(fqdn, domain):
+    if fqdn.endswith("." + domain):
+        return fqdn[:-(len("." + domain))]
+    return None

--- a/cloudar-acm-plus-custom-resource/src/index.py
+++ b/cloudar-acm-plus-custom-resource/src/index.py
@@ -2,108 +2,162 @@ import boto3
 import logging
 import cfnresponse
 import time
+import sys
+from helper import get_resource_property
+from dns.route53 import Route53
+from dns.menandmice import MenAndMice
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-def handler(event, context):
-    try:
-        if event['RequestType'] == "Create":
-            domain_name = get_resource_property(event, 'DomainName')
-            additional_domains = get_resource_property(event, 'AdditionalDomains')
-            validation_domain = get_resource_property(event, 'ValidationDomain')
-            certificate_region = get_resource_property(event, 'CertificateRegion')
-            certificate_tags = get_resource_property(event, 'CertificateTags')
-            hosted_zone_id = get_resource_property(event, 'HostedZoneId')
+class acm_certificate:
+    def __init__(self,event):
+        self.domain_name = get_resource_property(event, 'DomainName')
+        self.additional_domains = get_resource_property(event, 'AdditionalDomains')
+        self.validation_domain = get_resource_property(event, 'ValidationDomain')
+        self.certificate_region = get_resource_property(event, 'CertificateRegion')
+        self.certificate_tags = get_resource_property(event, 'CertificateTags')
+        self.dns_service = None
+        self.idem_potency_token = get_resource_property(event,
+                                                       'IdempotencyToken')
+        self.client = boto3.client('acm', region_name=self.certificate_region)
+        self.certificate_arn = None
 
-            certificate_arn = create_acm_certificate(event, context, domain_name, additional_domains, validation_domain, certificate_region)
+    def load_dns_handler(self,event):
+        self.dns_service = instantiate_class(
+            get_resource_property(event, 'DnsService'))
+        handle_event = getattr(self.dns_service, 'handle_event', None)
+        if callable(handle_event):
+            self.dns_service.handle_event(event)
 
-            if certificate_tags is not None:
-                add_tags_to_acm_certificate(certificate_region, certificate_arn, certificate_tags)
+    def set_certificate_arn(self,certificate_arn):
+        self.certificate_arn = certificate_arn
 
-            validate_acm_certificate(event, context, certificate_arn, certificate_region, additional_domains, hosted_zone_id)
+    def get_certificate_arn(self):
+        return self.certificate_arn
 
-            wait_for_cert_to_validate(event, context, certificate_arn, certificate_region)
-            send_cfnresponse(event, context, "SUCCESS", {'response': 'validated', 'certificate_arn': certificate_arn})
-        elif event['RequestType'] == "Delete":
-            certificate_region = get_resource_property(event, 'CertificateRegion')
-            hosted_zone_id = get_resource_property(event, 'HostedZoneId')
+    def get_certificate_region(self):
+        return self.certificate_region
 
-            certificate_arn = get_certificate_arn_from_cfn_stack(event, context, certificate_region)
-            deleting_records(event, context, certificate_region, certificate_arn, hosted_zone_id)
-            delete_certificate(event, context, certificate_arn, certificate_region)
-            send_cfnresponse(event, context, "SUCCESS", {'response': 'deleted', 'certificate_arn': certificate_arn})
+    def create_certificate(self):
+        if self.additional_domains is None:
+            response = self.client.request_certificate(
+                DomainName=self.domain_name,
+                ValidationMethod='DNS',
+                IdempotencyToken=self.idem_potency_token,
+                DomainValidationOptions=[
+                    {
+                        'DomainName': self.domain_name,
+                        'ValidationDomain': self.validation_domain
+                    },
+                ],
+                Options={
+                    'CertificateTransparencyLoggingPreference': 'ENABLED'
+                })
         else:
-            certificate_region = get_resource_property(event, 'CertificateRegion')
-            certificate_arn = get_certificate_arn_from_cfn_stack(event, context, certificate_region)
-            send_cfnresponse(event, context, "SUCCESS", {'response': 'skipped_because_update', 'certificate_arn': certificate_arn})
+            response = self.client.request_certificate(
+                DomainName=self.domain_name,
+                ValidationMethod='DNS',
+                SubjectAlternativeNames=self.additional_domains,
+                IdempotencyToken=self.idem_potency_token,
+                DomainValidationOptions=[
+                    {
+                        'DomainName': self.domain_name,
+                        'ValidationDomain': self.validation_domain
+                    },
+                ],
+                Options={
+                    'CertificateTransparencyLoggingPreference': 'ENABLED'
+                })
+        logger.info("Created acm certificate " + response['CertificateArn'])
+        self.set_certificate_arn(response['CertificateArn'])
 
-    except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
+    def delete_certificate(self):
+        logger.info("Deleting certificate: " + self.certificate_arn)
+        response = self.client.delete_certificate(CertificateArn=self.certificate_arn)
+        logger.info("Deleted certificate: " + self.certificate_arn)
 
-def deleting_records(event, context, certificate_region, certificate_arn, hosted_zone_id):
-    try:
-        client = boto3.client('acm', region_name=certificate_region)
-        response = client.describe_certificate(
-            CertificateArn=certificate_arn
-        )
+    def add_tags(self):
+        if self.certificate_tags is not None:
+            self.client.add_tags_to_certificate(
+                CertificateArn=self.certificate_arn,
+                Tags=self.certificate_tags)
+            logger.info("Added tags to certificate " + self.certificate_arn)
 
+    def validate_certificate(self):
+        number_of_additional_domains = 0
+        if self.additional_domains is not None:
+            number_of_additional_domains = len(self.additional_domains)
+
+        logger.info("Creating validation records.")
+
+        no_records = True
+
+        while no_records:
+            time.sleep(10)
+            response = self.client.describe_certificate(
+                CertificateArn=self.certificate_arn
+            )
+
+            if 'Certificate' in response:
+                crt_data = response['Certificate']
+                if 'DomainValidationOptions' in crt_data:
+                    validation_options = crt_data['DomainValidationOptions']
+                    if len(validation_options) == number_of_additional_domains +1:
+                        no_records = False
+                        for validations in validation_options:
+                            record = validations['ResourceRecord']
+                            self.dns_service.modify_dns_record('CREATE',record['Name'], record['Value'])
+
+        logger.info("Creating validation records complete.")
+
+    def wait_for_cert_to_validate(self):
+        logger.info("Waiting for certificate to validate.")
+
+        not_validated = True
+
+        while not_validated:
+            time.sleep(10)
+            response = self.client.describe_certificate(
+                CertificateArn=self.certificate_arn)
+
+            if 'Certificate' in response:
+                crt_data = response['Certificate']
+                status = crt_data['Status']
+                logger.info("Certificate status: " + status)
+                if status == "ISSUED":
+                    not_validated = False
+
+        logger.info("Certificate validated.")
+
+    def delete_records(self):
+        response = self.client.describe_certificate(CertificateArn=self.certificate_arn)
         crt_data = response['Certificate']
         validation_options = crt_data['DomainValidationOptions']
         for validations in validation_options:
             record = validations['ResourceRecord']
-            modify_dns_record(event, context, 'DELETE', hosted_zone_id, record['Name'], record['Value'], certificate_region)
-    except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
+            self.dns_service.modify_dns_record('DELETE',record['Name'], record['Value'])
 
-def dns_record_exists(event, context, hosted_zone_id, record_name, record_value, certificate_region):
+def handler(event, context):
     try:
-        logger.info("Checking if record already exists: Hosted Zone = %s, Record Name = %s, Record Value = %s.", hosted_zone_id, record_name, record_value)
-        start_record_name = record_name.split('.')[0]
-
-        r53_client = boto3.client('route53', region_name=certificate_region)
-        iterator = r53_client.get_paginator('list_resource_record_sets').paginate(HostedZoneId=hosted_zone_id)
-        for page in iterator:
-            for record in page.get('ResourceRecordSets'):
-                if record_name == record['Name']:
-                    logger.info("Record exists")
-                    return True
-
-        logger.info("Record does not exist")
-        return False
-
-    except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
-
-def modify_dns_record(event, context, action, hosted_zone_id, record_name, record_value, certificate_region):
-    try:
-        record_exists = dns_record_exists(event, context, hosted_zone_id, record_name, record_value, certificate_region)
-        if not record_exists or action == "DELETE":
-            r53_client = boto3.client('route53', region_name=certificate_region)
-            response = r53_client.change_resource_record_sets(
-                HostedZoneId=hosted_zone_id,
-                ChangeBatch={
-                    'Changes': [
-                        {
-                            'Action': action,
-                            'ResourceRecordSet': {
-                                'Name': record_name,
-                                'SetIdentifier': record_name,
-                                'TTL': 60,
-                                'Type': 'CNAME',
-                                'Region': certificate_region,
-                                'ResourceRecords': [
-                                    {
-                                        'Value': record_value
-                                    },
-                                ]
-                            }
-                        }
-                    ]
-                }
-            )
+        acm = acm_certificate(event)
+        if event['RequestType'] == "Create":
+            acm.load_dns_handler(event)
+            acm.add_tags()
+            acm.validate_certificate()
+            acm.wait_for_cert_to_validate()
+            send_cfnresponse(event, context, "SUCCESS", {'response': 'validated', 'certificate_arn': acm.get_certificate_arn()})
+        elif event['RequestType'] == "Delete":
+            acm.load_dns_handler(event)
+            certificate_arn = get_certificate_arn_from_cfn_stack(event, context, acm.get_certificate_region())
+            acm.set_certificate_arn(certificate_arn)
+            acm.delete_records()
+            acm.delete_certificate()
+            send_cfnresponse(event, context, "SUCCESS", {'response': 'deleted', 'certificate_arn': certificate_arn})
         else:
-            logger.info("Record exists, skipping create.")
+            certificate_arn = get_certificate_arn_from_cfn_stack(event, context, acm.get_certificate_region())
+            send_cfnresponse(event, context, "SUCCESS", {'response': 'skipped_because_update', 'certificate_arn': certificate_arn})
+
     except Exception as e:
         send_cfnresponse(event, context, "FAILED", {'error': str(e)})
 
@@ -128,128 +182,9 @@ def get_certificate_arn_from_cfn_stack(event, context, certificate_region):
     except Exception as e:
         send_cfnresponse(event, context, "FAILED", {'error': str(e)})
 
-def delete_certificate(event, context, certificate_arn, certificate_region):
-    try:
-        logger.info("Deleting certificate: " + certificate_arn)
-        client = boto3.client('acm', region_name=certificate_region)
-        response = client.delete_certificate(
-            CertificateArn=certificate_arn
-        )
-        logger.info("Deleted certificate: " + certificate_arn)
-    except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
-
-def wait_for_cert_to_validate(event, context, certificate_arn, certificate_region):
-    try:
-        logger.info("Waiting for certificate to validate.")
-        client = boto3.client('acm', region_name=certificate_region)
-
-        not_validated = True
-
-        while not_validated:
-            time.sleep(10)
-            response = client.describe_certificate(
-                CertificateArn=certificate_arn
-            )
-
-            if 'Certificate' in response:
-                crt_data = response['Certificate']
-                status = crt_data['Status']
-                logger.info("Certificate status: " + status)
-                if status == "ISSUED":
-                    not_validated = False
-
-        logger.info("Certificate validated.")
-    except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
-
-def validate_acm_certificate(event, context, certificate_arn, certificate_region, additional_domains, hosted_zone_id):
-    try:
-        number_of_additional_domains = 0
-        if additional_domains is not None:
-            number_of_additional_domains = len(additional_domains)
-
-        logger.info("Creating validation records.")
-        client = boto3.client('acm', region_name=certificate_region)
-
-        no_records = True
-
-        while no_records:
-            time.sleep(10)
-            response = client.describe_certificate(
-                CertificateArn=certificate_arn
-            )
-
-            if 'Certificate' in response:
-                crt_data = response['Certificate']
-                if 'DomainValidationOptions' in crt_data:
-                    validation_options = crt_data['DomainValidationOptions']
-                    if len(validation_options) == number_of_additional_domains +1:
-                        no_records = False
-                        for validations in validation_options:
-                            record = validations['ResourceRecord']
-                            modify_dns_record(event, context, 'CREATE', hosted_zone_id, record['Name'], record['Value'], certificate_region)
-
-        logger.info("Creating validation records complete.")
-    except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
-
-def create_acm_certificate(event, context, domain_name, additional_domains, validation_domain, certificate_region):
-    try:
-        client = boto3.client('acm', region_name=certificate_region)
-        idem_potency_token = get_resource_property(event, 'IdempotencyToken')
-
-        if additional_domains is None:
-            response = client.request_certificate(
-                DomainName=domain_name,
-                ValidationMethod='DNS',
-                IdempotencyToken=idem_potency_token,
-                DomainValidationOptions=[
-                    {
-                        'DomainName': domain_name,
-                        'ValidationDomain': validation_domain
-                    },
-                ],
-                Options={
-                    'CertificateTransparencyLoggingPreference': 'ENABLED'
-                }
-            )
-        else:
-            response = client.request_certificate(
-                DomainName=domain_name,
-                ValidationMethod='DNS',
-                SubjectAlternativeNames=additional_domains,
-                IdempotencyToken=idem_potency_token,
-                DomainValidationOptions=[
-                    {
-                        'DomainName': domain_name,
-                        'ValidationDomain': validation_domain
-                    },
-                ],
-                Options={
-                    'CertificateTransparencyLoggingPreference': 'ENABLED'
-                }
-            )
-        logger.info("Created acm certificate " + response['CertificateArn'])
-        return response['CertificateArn']
-    except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
-
-def add_tags_to_acm_certificate(certificate_region, certificate_arn, certificate_tags):
-    client = boto3.client('acm', region_name=certificate_region)
-    client.add_tags_to_certificate(
-        CertificateArn=certificate_arn,
-        Tags=certificate_tags
-    )
-    logger.info("Added tags to certificate " + certificate_arn)
-
-def get_resource_property(event, resource_property):
-    resource_properties = event['ResourceProperties']
-    if resource_property in resource_properties:
-        return resource_properties[resource_property]
-    else:
-        return None
-
+def instantiate_class(classname):
+    return getattr(sys.modules[__name__], classname)()
+    
 def send_cfnresponse(event, context, status, data):
     if status == "SUCCESS":
         cfnresponse.send(event, context, cfnresponse.SUCCESS, data)

--- a/cloudar-acm-plus-custom-resource/src/index.py
+++ b/cloudar-acm-plus-custom-resource/src/index.py
@@ -34,7 +34,10 @@ class acm_certificate:
         self.certificate_arn = certificate_arn
 
     def get_certificate_arn(self):
-        return self.certificate_arn
+        if self.certificate_arn:
+            return self.certificate_arn
+        else:
+            return ""
 
     def get_certificate_region(self):
         return self.certificate_region
@@ -143,6 +146,7 @@ def handler(event, context):
         acm = acm_certificate(event)
         if event['RequestType'] == "Create":
             acm.load_dns_handler(event)
+            acm.create_certificate()
             acm.add_tags()
             acm.validate_certificate()
             acm.wait_for_cert_to_validate()

--- a/cloudar-acm-plus-custom-resource/src/index.py
+++ b/cloudar-acm-plus-custom-resource/src/index.py
@@ -181,11 +181,6 @@ def get_certificate_arn_from_cfn_stack(event, context, certificate_region):
             LogicalResourceId=resource_id
         )
 
-        # for stack in response['Stacks']:
-        #     outputs = stack['Outputs']
-        #     for output in outputs:
-        #         if output['OutputKey'] == resource_id:
-        #             certificate_arn = output['OutputValue']
         resource = response['StackResources'][0]
         certificate_arn = resource['PhysicalResourceId']
 

--- a/cloudar-acm-plus-custom-resource/src/index.py
+++ b/cloudar-acm-plus-custom-resource/src/index.py
@@ -176,7 +176,7 @@ def get_certificate_arn_from_cfn_stack(event, context, certificate_region):
         certificate_arn = ""
 
         client = boto3.client('cloudformation', region_name=certificate_region)
-        response = client.describe_stacks(
+        response = client.describe_stack_resources(
             StackName=stack_id,
             LogicalResourceId=resource_id
         )

--- a/cloudar-acm-plus-custom-resource/src/index.py
+++ b/cloudar-acm-plus-custom-resource/src/index.py
@@ -3,35 +3,39 @@ import logging
 import cfnresponse
 import time
 import sys
+import re
 from helper import get_resource_property
 from dns.route53 import Route53
 from dns.menandmice import MenAndMice
-import re
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 class acm_certificate:
-    def __init__(self,event):
+    def __init__(self, event):
         self.domain_name = get_resource_property(event, 'DomainName')
-        self.additional_domains = get_resource_property(event, 'AdditionalDomains')
-        self.validation_domain = get_resource_property(event, 'ValidationDomain')
-        self.certificate_region = get_resource_property(event, 'CertificateRegion')
+        self.additional_domains = get_resource_property(
+            event, 'AdditionalDomains')
+        self.validation_domain = get_resource_property(
+            event, 'ValidationDomain')
+        self.certificate_region = get_resource_property(
+            event, 'CertificateRegion')
         self.certificate_tags = get_resource_property(event, 'CertificateTags')
         self.dns_service = None
         self.idem_potency_token = get_resource_property(event,
-                                                       'IdempotencyToken')
+                                                        'IdempotencyToken')
         self.client = boto3.client('acm', region_name=self.certificate_region)
         self.certificate_arn = None
 
-    def load_dns_handler(self,event):
+    def load_dns_handler(self, event):
         self.dns_service = instantiate_class(
             get_resource_property(event, 'DnsService'))
         handle_event = getattr(self.dns_service, 'handle_event', None)
         if callable(handle_event):
             self.dns_service.handle_event(event)
 
-    def set_certificate_arn(self,certificate_arn):
+    def set_certificate_arn(self, certificate_arn):
         self.certificate_arn = certificate_arn
 
     def get_certificate_arn(self):
@@ -64,7 +68,6 @@ class acm_certificate:
             # Sanity Checks for additional domains
             for san in self.additional_domains:
                 self.validate_rfc2181(san)
-                
             response = self.client.request_certificate(
                 DomainName=self.domain_name,
                 ValidationMethod='DNS',
@@ -84,7 +87,8 @@ class acm_certificate:
 
     def delete_certificate(self):
         logger.info("Deleting certificate: " + self.certificate_arn)
-        response = self.client.delete_certificate(CertificateArn=self.certificate_arn)
+        response = self.client.delete_certificate(
+            CertificateArn=self.certificate_arn)
         logger.info("Deleted certificate: " + self.certificate_arn)
 
     def add_tags(self):
@@ -94,22 +98,15 @@ class acm_certificate:
                 Tags=self.certificate_tags)
             logger.info("Added tags to certificate " + self.certificate_arn)
 
-    def validate_rfc1035(self,fqdn):
-        logger.info('RFC1035 Sanity Check of ' + fqdn)
-        rfc1035_pattern = r"(?=^.{4,253}\.?$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}\.?$)"
-        result = re.match(rfc1035_pattern,fqdn)
-        if not result:
-            raise ValueError('RFC1035 Sanity Check fails: ' + fqdn + ' is not a valid FQDN')
-        return True
-
     def validate_rfc2181(self, fqdn):
         logger.info('RFC2181 Sanity Check of ' + fqdn)
         rfc2181_pattern = r"(?=^.{4,253}\.?$)(^((?!-)[^\.]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}\.?$)"
         result = re.match(rfc2181_pattern, fqdn)
         if not result:
-            raise ValueError('RFC2181 Sanity Check fails: ' +
-                             fqdn + ' is not a valid FQDN')
+            raise ValueError('RFC2181 Sanity Check fails: ' + fqdn +
+                             ' is not a valid FQDN')
         return True
+
     def validate_certificate(self):
         number_of_additional_domains = 0
         if self.additional_domains is not None:
@@ -129,12 +126,13 @@ class acm_certificate:
                 crt_data = response['Certificate']
                 if 'DomainValidationOptions' in crt_data:
                     validation_options = crt_data['DomainValidationOptions']
-                    if len(validation_options) == number_of_additional_domains +1:
+                    if len(validation_options) == number_of_additional_domains + 1:
                         no_records = False
                         for validations in validation_options:
                             record = validations['ResourceRecord']
                             self.validate_rfc2181(record['Name'])
-                            self.dns_service.modify_dns_record('CREATE',record['Name'], record['Value'])
+                            self.dns_service.modify_dns_record(
+                                'CREATE', record['Name'], record['Value'])
 
         logger.info("Creating validation records complete.")
 
@@ -158,46 +156,57 @@ class acm_certificate:
         logger.info("Certificate validated.")
 
     def delete_records(self):
-        response = self.client.describe_certificate(CertificateArn=self.certificate_arn)
+        response = self.client.describe_certificate(
+            CertificateArn=self.certificate_arn)
         crt_data = response['Certificate']
         validation_options = crt_data['DomainValidationOptions']
         for validations in validation_options:
             record = validations['ResourceRecord']
-            self.dns_service.modify_dns_record('DELETE',record['Name'], record['Value'])
+            self.dns_service.modify_dns_record(
+                'DELETE', record['Name'], record['Value'])
+
 
 def handler(event, context):
+    certificate_arn = None
     try:
         acm = acm_certificate(event)
         if event['RequestType'] == "Create":
             acm.load_dns_handler(event)
             acm.create_certificate()
             acm.add_tags()
+            certificate_arn = acm.get_certificate_arn()
             acm.validate_certificate()
             acm.wait_for_cert_to_validate()
-            certificate_arn = acm.get_certificate_arn()
+            # certificate_arn = acm.get_certificate_arn()
             send_cfnresponse(event, context, "SUCCESS", {
                              'response': 'validated', 'certificate_arn': certificate_arn}, certificate_arn)
         elif event['RequestType'] == "Delete":
             acm.load_dns_handler(event)
-            certificate_arn = get_certificate_arn_from_cfn_stack(event, context, acm.get_certificate_region())
+            print("Deleting...")
+            print(event)
+            certificate_arn = get_certificate_arn_from_cfn_stack(
+                event, context, acm.get_certificate_region())
             acm.set_certificate_arn(certificate_arn)
             acm.delete_records()
             acm.delete_certificate()
             send_cfnresponse(event, context, "SUCCESS", {
                              'response': 'deleted', 'certificate_arn': certificate_arn}, certificate_arn)
         else:
-            certificate_arn = get_certificate_arn_from_cfn_stack(event, context, acm.get_certificate_region())
+            certificate_arn = get_certificate_arn_from_cfn_stack(
+                event, context, acm.get_certificate_region())
             send_cfnresponse(event, context, "SUCCESS", {
                              'response': 'skipped_because_update', 'certificate_arn': certificate_arn}, certificate_arn)
 
     except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
+        send_cfnresponse(event, context, "FAILED", {
+                         'error': str(e)}, certificate_arn)
+
 
 def get_certificate_arn_from_cfn_stack(event, context, certificate_region):
+    certificate_arn = None
     try:
         resource_id = event['LogicalResourceId']
         stack_id = event['StackId']
-        certificate_arn = ""
 
         client = boto3.client('cloudformation', region_name=certificate_region)
         response = client.describe_stack_resources(
@@ -210,13 +219,15 @@ def get_certificate_arn_from_cfn_stack(event, context, certificate_region):
 
         return certificate_arn
     except Exception as e:
-        send_cfnresponse(event, context, "FAILED", {'error': str(e)})
+        send_cfnresponse(event, context, "FAILED", {
+                         'error': str(e)}, certificate_arn)
+
 
 def instantiate_class(classname):
     return getattr(sys.modules[__name__], classname)()
-    
 
-def send_cfnresponse(event, context, status, data, physicalResourceId = None):
+
+def send_cfnresponse(event, context, status, data, physicalResourceId=None):
     if status == "SUCCESS":
         cfnresponse.send(event, context, cfnresponse.SUCCESS,
                          data, physicalResourceId)


### PR DESCRIPTION
This PR allows the ACM Auto validation to also work with external DNS solutions.
The DNS manipulation process is modularized and can be selected from within the Cloudformation template.
Currently 2 solutions are supported: Route53 and MenAndMice ( Tested against M&M 9.2 )
Furthermore, a rudimentary sanity check has been added to conform to RFC2181